### PR TITLE
feat: add decode_token utility

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,4 +21,4 @@ jobs:
 
       - name: Run benchmarks
         continue-on-error: true
-        run: go test -benchmem -bench=".*" "go.baoshuo.dev/csslexer/bench" 
+        run: go test -v -benchmem -bench=".*" "go.baoshuo.dev/csslexer/bench" 

--- a/decode_token.go
+++ b/decode_token.go
@@ -1,0 +1,142 @@
+package csslexer
+
+import (
+	"slices"
+	"strings"
+)
+
+// DecodeToken decodes a CSS token based on its type and raw rune slice.
+// It handles escape sequences for identifier-like tokens, strings, and URLs.
+func DecodeToken(tokenType TokenType, raw []rune) string {
+	switch tokenType {
+	case IdentToken, FunctionToken, AtKeywordToken, HashToken, DimensionToken:
+		return decodeIdentLikeToken(raw)
+	case StringToken:
+		return decodeStringToken(raw)
+	case UrlToken:
+		return decodeUrlToken(raw)
+	default:
+		return string(raw)
+	}
+}
+
+// decodeIdentLikeToken decodes escape sequences in identifier-like tokens
+// This includes ident, function, at-keyword, hash, and dimension tokens
+func decodeIdentLikeToken(raw []rune) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	return decodeEscapeSequences(raw)
+}
+
+// decodeStringToken decodes escape sequences in string tokens
+func decodeStringToken(raw []rune) string {
+	if len(raw) < 2 {
+		return string(raw)
+	}
+
+	// Remove quotes and decode escape sequences
+	content := raw[1 : len(raw)-1] // Remove surrounding quotes
+	return decodeEscapeSequences(content)
+}
+
+// decodeUrlToken decodes escape sequences in URL tokens
+func decodeUrlToken(raw []rune) string {
+	if len(raw) < 2 {
+		return string(raw)
+	}
+
+	// Find the first parenthesis
+	parenIdx := slices.Index(raw, '(')
+	if parenIdx == -1 {
+		// No parenthesis found, decode the entire raw
+		return decodeEscapeSequences(raw)
+	}
+
+	prefix := decodeEscapeSequences(raw[:parenIdx])
+
+	// the content inside the parentheses
+	start := parenIdx + 1
+	end := len(raw)
+	if end > 0 && raw[end-1] == ')' {
+		end--
+	}
+
+	// Skip leading and trailing whitespace
+	for start < end && isHTMLWhitespace(raw[start]) {
+		start++
+	}
+	for end > start && isHTMLWhitespace(raw[end-1]) {
+		end--
+	}
+
+	content := raw[start:end]
+	contentStr := decodeEscapeSequences(content)
+
+	return prefix + "(" + contentStr + ")"
+}
+
+// decodeEscapeSequences is a common function to decode escape sequences
+// in a rune slice
+func decodeEscapeSequences(runes []rune) string {
+	if len(runes) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(runes)) // Pre-allocate capacity
+
+	i := 0
+	for i < len(runes) {
+		if runes[i] == '\\' && i+1 < len(runes) && twoCharsAreValidEscape(runes[i], runes[i+1]) {
+			// Handle escape sequence
+			decoded := consumeEscapeSequence(runes, &i)
+			builder.WriteRune(decoded)
+		} else {
+			builder.WriteRune(runes[i])
+			i++
+		}
+	}
+
+	return builder.String()
+}
+
+// consumeEscapeSequence consumes an escape sequence from the rune slice
+// starting at index i and returns the decoded rune. The index i is updated
+// to point to the next character after the escape sequence.
+func consumeEscapeSequence(runes []rune, i *int) rune {
+	*i++ // Skip the backslash
+
+	if *i >= len(runes) {
+		return '\uFFFD' // Replacement character for EOF
+	}
+
+	c := runes[*i]
+
+	if isASCIIHexDigit(c) {
+		// Hex escape sequence: \123456
+		var res rune = 0
+		hexCount := 0
+
+		for hexCount < 6 && *i < len(runes) && isASCIIHexDigit(runes[*i]) {
+			res = res*16 + hexDigitToValue(runes[*i])
+			*i++
+			hexCount++
+		}
+
+		// Skip trailing whitespace after hex escape
+		if *i < len(runes) && isHTMLWhitespace(runes[*i]) {
+			*i++
+		}
+
+		if !isValidCodePoint(res) {
+			return '\uFFFD' // Replacement character
+		}
+
+		return res
+	} else {
+		// Single character escape: \n, \", \\, etc.
+		*i++
+		return c
+	}
+}

--- a/decode_token.go
+++ b/decode_token.go
@@ -1,7 +1,6 @@
 package csslexer
 
 import (
-	"slices"
 	"strings"
 )
 
@@ -12,60 +11,11 @@ import (
 // Return: the decoded string representation of the token.
 func DecodeToken(tokenType TokenType, raw []rune) string {
 	switch tokenType {
-	case IdentToken, FunctionToken, AtKeywordToken, HashToken, DimensionToken:
-		return decodeIdentLikeToken(raw)
-	case StringToken:
-		return decodeStringToken(raw)
-	case UrlToken:
-		return decodeUrlToken(raw)
+	case IdentToken, FunctionToken, AtKeywordToken, HashToken, DimensionToken, StringToken, UrlToken:
+		return decodeEscapeSequences(raw)
 	default:
 		return string(raw)
 	}
-}
-
-// decodeIdentLikeToken decodes escape sequences in identifier-like tokens.
-//
-// This includes ident, function, at-keyword, hash, and dimension tokens.
-func decodeIdentLikeToken(raw []rune) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	return decodeEscapeSequences(raw)
-}
-
-// decodeStringToken decodes escape sequences in string tokens.
-func decodeStringToken(raw []rune) string {
-	return decodeEscapeSequences(raw)
-}
-
-// decodeUrlToken decodes escape sequences in URL tokens.
-func decodeUrlToken(raw []rune) string {
-	if len(raw) < 2 {
-		return string(raw)
-	}
-
-	// Find the first opening parenthesis, which marks the start of the URL content.
-	// If no parenthesis is found, decode the entire raw token as a fallback.
-	// Only the first parenthesis is considered, as per CSS syntax for url tokens.
-	parenIdx := slices.Index(raw, '(')
-	if parenIdx == -1 {
-		// No parenthesis found, decode the entire raw
-		return decodeEscapeSequences(raw)
-	}
-
-	prefix := decodeEscapeSequences(raw[:parenIdx])
-
-	// the content inside the parentheses
-	start := parenIdx + 1
-	end := len(raw)
-	if end > 0 && raw[end-1] == ')' {
-		end--
-	}
-
-	// decode the content inside parentheses
-	content := decodeEscapeSequences(raw[start:end])
-
-	return prefix + "(" + content + ")"
 }
 
 // decodeEscapeSequences is a common function to decode escape sequences

--- a/decode_token.go
+++ b/decode_token.go
@@ -6,12 +6,10 @@ import (
 )
 
 // DecodeToken decodes a CSS token based on its type and raw rune slice.
+//
 // It handles escape sequences for identifier-like tokens, strings, and URLs.
 //
-// It returns the decoded string representation of the token.
-//
-// NOTE: 1) For string-token, it removes surrounding quotes. 2) For url-token,
-// it removes whitespace around the content inside parentheses.
+// Return: the decoded string representation of the token.
 func DecodeToken(tokenType TokenType, raw []rune) string {
 	switch tokenType {
 	case IdentToken, FunctionToken, AtKeywordToken, HashToken, DimensionToken:
@@ -27,7 +25,7 @@ func DecodeToken(tokenType TokenType, raw []rune) string {
 
 // decodeIdentLikeToken decodes escape sequences in identifier-like tokens.
 //
-// This includes ident, function, at-keyword, hash, and dimension tokens
+// This includes ident, function, at-keyword, hash, and dimension tokens.
 func decodeIdentLikeToken(raw []rune) string {
 	if len(raw) == 0 {
 		return ""
@@ -36,21 +34,11 @@ func decodeIdentLikeToken(raw []rune) string {
 }
 
 // decodeStringToken decodes escape sequences in string tokens.
-//
-// NOTE: It removes surrounding quotes of the string.
 func decodeStringToken(raw []rune) string {
-	if len(raw) < 2 {
-		return string(raw)
-	}
-
-	// Remove quotes and decode escape sequences
-	content := raw[1 : len(raw)-1] // Remove surrounding quotes
-	return decodeEscapeSequences(content)
+	return decodeEscapeSequences(raw)
 }
 
 // decodeUrlToken decodes escape sequences in URL tokens.
-//
-// NOTE: It removes the whitespace around the content inside parentheses.
 func decodeUrlToken(raw []rune) string {
 	if len(raw) < 2 {
 		return string(raw)
@@ -74,18 +62,10 @@ func decodeUrlToken(raw []rune) string {
 		end--
 	}
 
-	// Skip leading and trailing whitespace
-	for start < end && isHTMLWhitespace(raw[start]) {
-		start++
-	}
-	for end > start && isHTMLWhitespace(raw[end-1]) {
-		end--
-	}
+	// decode the content inside parentheses
+	content := decodeEscapeSequences(raw[start:end])
 
-	content := raw[start:end]
-	contentStr := decodeEscapeSequences(content)
-
-	return prefix + "(" + contentStr + ")"
+	return prefix + "(" + content + ")"
 }
 
 // decodeEscapeSequences is a common function to decode escape sequences

--- a/decode_token.go
+++ b/decode_token.go
@@ -7,6 +7,11 @@ import (
 
 // DecodeToken decodes a CSS token based on its type and raw rune slice.
 // It handles escape sequences for identifier-like tokens, strings, and URLs.
+//
+// It returns the decoded string representation of the token.
+//
+// NOTE: 1) For string-token, it removes surrounding quotes. 2) For url-token,
+// it removes whitespace around the content inside parentheses.
 func DecodeToken(tokenType TokenType, raw []rune) string {
 	switch tokenType {
 	case IdentToken, FunctionToken, AtKeywordToken, HashToken, DimensionToken:
@@ -20,7 +25,8 @@ func DecodeToken(tokenType TokenType, raw []rune) string {
 	}
 }
 
-// decodeIdentLikeToken decodes escape sequences in identifier-like tokens
+// decodeIdentLikeToken decodes escape sequences in identifier-like tokens.
+//
 // This includes ident, function, at-keyword, hash, and dimension tokens
 func decodeIdentLikeToken(raw []rune) string {
 	if len(raw) == 0 {
@@ -29,7 +35,9 @@ func decodeIdentLikeToken(raw []rune) string {
 	return decodeEscapeSequences(raw)
 }
 
-// decodeStringToken decodes escape sequences in string tokens
+// decodeStringToken decodes escape sequences in string tokens.
+//
+// NOTE: It removes surrounding quotes of the string.
 func decodeStringToken(raw []rune) string {
 	if len(raw) < 2 {
 		return string(raw)
@@ -40,7 +48,9 @@ func decodeStringToken(raw []rune) string {
 	return decodeEscapeSequences(content)
 }
 
-// decodeUrlToken decodes escape sequences in URL tokens
+// decodeUrlToken decodes escape sequences in URL tokens.
+//
+// NOTE: It removes the whitespace around the content inside parentheses.
 func decodeUrlToken(raw []rune) string {
 	if len(raw) < 2 {
 		return string(raw)
@@ -77,7 +87,7 @@ func decodeUrlToken(raw []rune) string {
 }
 
 // decodeEscapeSequences is a common function to decode escape sequences
-// in a rune slice
+// in a rune slice.
 func decodeEscapeSequences(runes []rune) string {
 	if len(runes) == 0 {
 		return ""

--- a/decode_token.go
+++ b/decode_token.go
@@ -56,7 +56,9 @@ func decodeUrlToken(raw []rune) string {
 		return string(raw)
 	}
 
-	// Find the first parenthesis
+	// Find the first opening parenthesis, which marks the start of the URL content.
+	// If no parenthesis is found, decode the entire raw token as a fallback.
+	// Only the first parenthesis is considered, as per CSS syntax for url tokens.
 	parenIdx := slices.Index(raw, '(')
 	if parenIdx == -1 {
 		// No parenthesis found, decode the entire raw

--- a/decode_token_test.go
+++ b/decode_token_test.go
@@ -55,7 +55,7 @@ func TestDecodeToken(t *testing.T) {
 		},
 		{
 			name:      "default type",
-			tokenType: DefaultToken,
+			tokenType: IdentToken,
 			input:     "foo",
 			expect:    "foo",
 		},

--- a/decode_token_test.go
+++ b/decode_token_test.go
@@ -1,0 +1,71 @@
+package csslexer
+
+import (
+	"testing"
+)
+
+func TestDecodeToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenType TokenType
+		input     string
+		expect    string
+	}{
+		{
+			name:      "ident with escape",
+			tokenType: IdentToken,
+			input:     `foo\20 bar`,
+			expect:    `foo bar`,
+		},
+		{
+			name:      "string with escape",
+			tokenType: StringToken,
+			input:     `"foo\22 bar"`,
+			expect:    `foo"bar`,
+		},
+		{
+			name:      "url with escape in prefix and content",
+			tokenType: UrlToken,
+			input:     `u\72 l(foo\20 bar)`,
+			expect:    `url(foo bar)`,
+		},
+		{
+			name:      "hash with escape",
+			tokenType: HashToken,
+			input:     `#foo\20 bar`,
+			expect:    `#foo bar`,
+		},
+		{
+			name:      "dimension with escape",
+			tokenType: DimensionToken,
+			input:     `10p\78`,
+			expect:    `10px`,
+		},
+		{
+			name:      "at-keyword with escape",
+			tokenType: AtKeywordToken,
+			input:     `@f\6fobar`,
+			expect:    `@foobar`,
+		},
+		{
+			name:      "function with escape",
+			tokenType: FunctionToken,
+			input:     `\63 alc(`,
+			expect:    `calc(`,
+		},
+		{
+			name:      "default type",
+			tokenType: DefaultToken,
+			input:     "foo",
+			expect:    "foo",
+		},
+	}
+
+	for _, tc := range tests {
+		raw := []rune(tc.input)
+		got := DecodeToken(tc.tokenType, raw)
+		if got != tc.expect {
+			t.Errorf("%s: got '%s', want '%s'", tc.name, got, tc.expect)
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `DecodeToken` utility for decoding CSS tokens, along with a comprehensive set of unit tests to ensure correct behavior. The main focus is on handling escape sequences for various CSS token types and normalizing their string representations.
